### PR TITLE
Rename GitRepositorys property

### DIFF
--- a/S1EORI_HFT_2022232.Repository/AppDbContext.cs
+++ b/S1EORI_HFT_2022232.Repository/AppDbContext.cs
@@ -7,7 +7,7 @@ namespace S1EORI_HFT_2022232.Repository
     public class AppDbContext : DbContext
     {
         public DbSet<User> Users { get; set; }
-        public DbSet<GitRepository> GitRepositorys { get; set; }
+        public DbSet<GitRepository> GitRepositories { get; set; }
         public DbSet<Commit> Commits { get; set; }
         public AppDbContext()
         {

--- a/S1EORI_HFT_2022232.Repository/ModelsRepository/GitRepositoryRepository.cs
+++ b/S1EORI_HFT_2022232.Repository/ModelsRepository/GitRepositoryRepository.cs
@@ -16,7 +16,7 @@ namespace S1EORI_HFT_2022232.Repository.ModelsRepository
 
         public override GitRepository Read(int id)
         {
-            return _context.GitRepositorys.FirstOrDefault(e => e.IdGitRepository == id);
+            return _context.GitRepositories.FirstOrDefault(e => e.IdGitRepository == id);
 
         }
         public override void Update(GitRepository item)


### PR DESCRIPTION
## Summary
- rename `GitRepositorys` DbSet in `AppDbContext` to `GitRepositories`
- fix reference in `GitRepositoryRepository`

## Testing
- `dotnet build S1EORI_HFT_2022232.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b0af52483279e7050d1044d6976